### PR TITLE
Library simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*venv*
+*.ipynb_checkpoints*

--- a/library_simulation/library_books.ipynb
+++ b/library_simulation/library_books.ipynb
@@ -7,9 +7,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import csv\n",
     "from datetime import datetime\n",
     "from faker import Faker\n",
-    "import numpy as np"
+    "import numpy as np\n"
    ]
   },
   {
@@ -30,6 +31,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# If you change the max number of authors, publishers, or titles,\n",
+    "# consider changing the distribution shape so things still look reasonable.\n",
+    "\n",
     "AUTHOR_DIST_SHAPE = 3\n",
     "MAX_NUM_AUTHORS = 300\n",
     "\n",
@@ -37,7 +41,9 @@
     "MAX_NUM_PUBLISHERS = 15\n",
     "\n",
     "TITLES_DIST_SHAPE = 1\n",
-    "NUM_TITLES = 1000"
+    "NUM_TITLES = 1000\n",
+    "\n",
+    "NUM_PATRONS = 1000"
    ]
   },
   {
@@ -63,23 +69,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_author_dict():\n",
-    "    first_name = fake.first_name()\n",
-    "    last_name = fake.last_name()\n",
-    "    return {\n",
-    "        'first_name': first_name,\n",
-    "        'last_name': last_name,\n",
-    "        'website': get_author_website(first_name, last_name) if rng.random() > 0.3 else None\n",
-    "    }\n",
-    "\n",
-    "\n",
-    "def get_author_website(first_name, last_name):\n",
+    " def get_author_website(first_name, last_name):\n",
     "    scheme = rng.choice(['https', 'http'], p=[0.8, 0.2])\n",
     "    return f'{scheme}://{last_name if rng.random() > 0.5 else first_name + last_name}.{fake.tld()}'.lower()\n",
     "\n",
+    "\n",
     "author_raw_distribution = rng.gamma(AUTHOR_DIST_SHAPE, size=MAX_NUM_AUTHORS)\n",
     "author_distribution = author_raw_distribution / sum(author_raw_distribution)\n",
-    "author_list = [get_author_dict() for _ in range(MAX_NUM_AUTHORS)]\n",
+    "author_list = [\n",
+    "    {\n",
+    "        'first_name': (first_name := fake.first_name()),\n",
+    "        'last_name': (last_name := fake.last_name()),\n",
+    "        'website': get_author_website(first_name, last_name) if rng.random() > 0.3 else None\n",
+    "    }\n",
+    "    for _ in range(MAX_NUM_AUTHORS)\n",
+    "]\n",
     "\n",
     "def get_random_author():\n",
     "    return rng.choice(author_list, p=author_distribution)\n",
@@ -104,7 +108,7 @@
     "    publication_year,\n",
     "    num_copies,\n",
     "):\n",
-    "    if num_copies == 0:\n",
+    "    if num_copies <= 0:\n",
     "        return []\n",
     "    \n",
     "    if rng.random() > 0.8 and publication_year < 2022:  # we update publication info\n",
@@ -173,20 +177,65 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ef060a1",
+   "id": "d190ee42",
    "metadata": {},
    "outputs": [],
    "source": [
-    "books"
+    "book_fields = [\n",
+    "    'title',\n",
+    "    'isbn',\n",
+    "    'author_first_name',\n",
+    "    'author_last_name',\n",
+    "    'author_website',\n",
+    "    'publisher',\n",
+    "    'publication_year',\n",
+    "    'acquisition_date',\n",
+    "    'acquisition_price',\n",
+    "]\n",
+    "with open('books_sim.tsv', 'w', newline='') as f:\n",
+    "    writer = csv.DictWriter(f, book_fields, dialect='excel-tab')\n",
+    "    writer.writeheader()\n",
+    "    writer.writerows(books)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d190ee42",
+   "id": "d3f32912",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "def get_personal_email(first_name, last_name):\n",
+    "    abbr_first_name = rng.choice([first_name, first_name[0]])\n",
+    "    abbr_last_name = rng.choice([last_name, last_name[0]]) if len(abbr_first_name) > 3 else last_name\n",
+    "    separator = rng.choice(['.', ''])\n",
+    "    number = rng.integers(5, high=99) if rng.random() > 0.5 else ''\n",
+    "    return f'{abbr_first_name}{separator}{abbr_last_name}{number}@{fake.domain_name()}'.lower()\n",
+    "\n",
+    "\n",
+    "patron_list = [\n",
+    "    {\n",
+    "        'first_name': (first_name := fake.first_name()), \n",
+    "        'last_name': (last_name := fake.last_name()), \n",
+    "        'email': get_personal_email(first_name, last_name)\n",
+    "    }\n",
+    "    for _ in range(NUM_PATRONS)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85cefe78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "patron_fields = ['first_name', 'last_name', 'email']\n",
+    "with open ('patrons_sim.tsv', 'w', newline='') as f:\n",
+    "    writer = csv.DictWriter(f, patron_fields, dialect='excel')\n",
+    "    writer.writeheader()\n",
+    "    writer.writerows(patron_list)"
+   ]
   }
  ],
  "metadata": {

--- a/library_simulation/library_books.ipynb
+++ b/library_simulation/library_books.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "286b5411",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from faker import Faker\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af5b2dac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake = Faker()\n",
+    "rng = np.random.default_rng()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c30f07b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AUTHOR_DIST_SHAPE = 3\n",
+    "MAX_NUM_AUTHORS = 300\n",
+    "\n",
+    "PUBLISHER_DIST_SHAPE = 1\n",
+    "MAX_NUM_PUBLISHERS = 15\n",
+    "\n",
+    "TITLES_DIST_SHAPE = 1\n",
+    "NUM_TITLES = 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85d4b4a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "publisher_raw_distribution = rng.gamma(PUBLISHER_DIST_SHAPE, size=MAX_NUM_PUBLISHERS)\n",
+    "publisher_distribution = publisher_raw_distribution  / sum(publisher_raw_distribution)\n",
+    "publisher_list = [fake.company() for _ in range(MAX_NUM_PUBLISHERS)]\n",
+    "def get_random_publisher():\n",
+    "    return rng.choice(publisher_list, p=publisher_distribution)\n",
+    "\n",
+    "sorted(list(publisher_distribution * NUM_TITLES))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5468716d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_author_dict():\n",
+    "    first_name = fake.first_name()\n",
+    "    last_name = fake.last_name()\n",
+    "    return {\n",
+    "        'first_name': first_name,\n",
+    "        'last_name': last_name,\n",
+    "        'website': get_author_website(first_name, last_name) if rng.random() > 0.3 else None\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def get_author_website(first_name, last_name):\n",
+    "    scheme = rng.choice(['https', 'http'], p=[0.8, 0.2])\n",
+    "    return f'{scheme}://{last_name if rng.random() > 0.5 else first_name + last_name}.{fake.tld()}'.lower()\n",
+    "\n",
+    "author_raw_distribution = rng.gamma(AUTHOR_DIST_SHAPE, size=MAX_NUM_AUTHORS)\n",
+    "author_distribution = author_raw_distribution / sum(author_raw_distribution)\n",
+    "author_list = [get_author_dict() for _ in range(MAX_NUM_AUTHORS)]\n",
+    "\n",
+    "def get_random_author():\n",
+    "    return rng.choice(author_list, p=author_distribution)\n",
+    "\n",
+    "sorted([min(author_distribution) * NUM_TITLES, max(author_distribution) * NUM_TITLES])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9517522c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_book_copies(\n",
+    "    title, \n",
+    "    isbn,\n",
+    "    author_first_name, \n",
+    "    author_last_name, \n",
+    "    author_website, \n",
+    "    publisher, \n",
+    "    publication_year,\n",
+    "    num_copies,\n",
+    "):\n",
+    "    if num_copies == 0:\n",
+    "        return []\n",
+    "    \n",
+    "    if rng.random() > 0.8 and publication_year < 2022:  # we update publication info\n",
+    "        isbn = fake.isbn10()\n",
+    "        publisher = get_random_publisher() if rng.random() > 0.6 else publisher\n",
+    "        publication_year = rng.integers(publication_year, high=2022)\n",
+    "    \n",
+    "    return [\n",
+    "        {\n",
+    "            'title': title,\n",
+    "            'isbn': isbn,\n",
+    "            'author_first_name': author_first_name,\n",
+    "            'author_last_name': author_last_name,\n",
+    "            'author_website': author_website,\n",
+    "            'publisher': publisher,\n",
+    "            'publication_year': publication_year,\n",
+    "            'acquisition_date': fake.date_between(datetime(publication_year, 1, 1), 'today').strftime('%Y-%m-%d'),\n",
+    "            'acquisition_price': f'${rng.random() * 15:.2f}',\n",
+    "        }\n",
+    "    ] + get_book_copies(\n",
+    "        title, \n",
+    "        isbn,\n",
+    "        author_first_name, \n",
+    "        author_last_name, \n",
+    "        author_website, \n",
+    "        publisher, \n",
+    "        publication_year,\n",
+    "        num_copies - 1,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64dc04ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "books = [\n",
+    "    book_row\n",
+    "    for _ in range(NUM_TITLES)\n",
+    "    for author_dict in [get_random_author()]\n",
+    "    for book_row in get_book_copies(\n",
+    "        fake.text(max_nb_chars=30).strip('.').title(),\n",
+    "        fake.isbn10(),\n",
+    "        author_dict['first_name'],\n",
+    "        author_dict['last_name'],\n",
+    "        author_dict['website'],\n",
+    "        get_random_publisher(),\n",
+    "        rng.integers(1900, high=2022),\n",
+    "        int(rng.gamma(1, 2)) + 1\n",
+    "    )\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bfa23b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(books)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ef060a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "books"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d190ee42",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/library_simulation/requirements.txt
+++ b/library_simulation/requirements.txt
@@ -1,0 +1,4 @@
+faker
+jupyter
+numpy
+


### PR DESCRIPTION
This adds a Jupyter notebook that simulates a library collection, and some patrons. The output is a pair of CSVs.

It's intended to be used for an upcoming demo, and also for experimentation related to automatically choosing columns with repetitive data to be extracted to their own table.